### PR TITLE
fix(typo): Small typo in keycloak-integration.md

### DIFF
--- a/src/docs/keycloak-integration.md
+++ b/src/docs/keycloak-integration.md
@@ -65,7 +65,7 @@ keycloak.public-client=true
 keycloak.principal-attribute=preferred_username
 ```
 
-Finally create `keycloak-hawito.json` under `src/main/resources` in the Spring Boot project (which serves as the client-side Hawtio JS configuration):
+Finally create `keycloak-hawtio.json` under `src/main/resources` in the Spring Boot project (which serves as the client-side Hawtio JS configuration):
 
 ```json
 {


### PR DESCRIPTION
Hello, here a small typo I found, by looking at the Keycloak integration documentation. 